### PR TITLE
不具合修正: issue #1〜#4 の対応

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,14 +25,18 @@ class UsersController < ApplicationController
   def update
     failed_records = {}
 
-    params[:attendances]&.each do |id, attrs|
-      attendance = @user.attendances.find(id)
-      attendance.assign_attributes(attendance_params(attrs))
-      failed_records[attendance.id] = attendance unless attendance.save(context: :edit_attendance)
+    ActiveRecord::Base.transaction do
+      params[:attendances]&.each do |id, attrs|
+        attendance = @user.attendances.find(id)
+        processed = parse_overnight_time(attendance_params(attrs), attendance.worked_on)
+        attendance.assign_attributes(processed)
+        failed_records[attendance.id] = attendance unless attendance.save(context: :edit_attendance)
+      end
+      raise ActiveRecord::Rollback if failed_records.any?
     end
 
     if failed_records.empty?
-      redirect_to @user, notice: "勤怠情報を更新しました。"
+      redirect_to user_path(@user, date: @first_day), notice: "勤怠情報を更新しました。"
     else
       @attendances = @attendances.map { |a| failed_records[a.id] || a }
       render :edit, status: :unprocessable_entity
@@ -58,7 +62,31 @@ class UsersController < ApplicationController
   private
 
   def attendance_params(attrs)
-    attrs.permit(:started_at, :finished_at, :note)
+    attrs.permit(:started_at_hour, :started_at_minute, :finished_at_hour, :finished_at_minute, :note)
+  end
+
+  def parse_overnight_time(attrs, worked_on)
+    result = { note: attrs[:note] }
+
+    if attrs[:started_at_hour].present? && attrs[:started_at_minute].present?
+      result[:started_at] = worked_on.beginning_of_day +
+                            attrs[:started_at_hour].to_i.hours +
+                            attrs[:started_at_minute].to_i.minutes
+    else
+      result[:started_at] = nil
+    end
+
+    if attrs[:finished_at_hour].present? && attrs[:finished_at_minute].present?
+      hours = attrs[:finished_at_hour].to_i
+      minutes = attrs[:finished_at_minute].to_i
+      base_date = hours >= 24 ? worked_on.tomorrow : worked_on
+      adjusted_hours = hours >= 24 ? hours - 24 : hours
+      result[:finished_at] = base_date.beginning_of_day + adjusted_hours.hours + minutes.minutes
+    else
+      result[:finished_at] = nil
+    end
+
+    result
   end
 
   def basic_info_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,12 +29,4 @@ module ApplicationHelper
     end
   end
 
-  # 今日の行に表示するボタン種別を返す
-  def attendance_state(attendance)
-    if Date.current == attendance.worked_on
-      return '出勤' if attendance.started_at.nil?
-      return '退勤' if attendance.started_at.present? && attendance.finished_at.nil?
-    end
-    false
-  end
 end

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -1,4 +1,5 @@
 class Attendance < ApplicationRecord
+
   belongs_to :user
 
   validates :worked_on, presence: true

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(url: user_path(@user), method: :patch) do |f| %>
+<%= form_with(url: user_path(@user, date: @first_day), method: :patch) do |f| %>
   <% if @attendances.any? { |a| a.errors.any? } %>
     <div class="alert alert-danger mt-3">
       <ul class="mb-0">
@@ -32,10 +32,52 @@
 
             <% future = day.worked_on > Date.current %>
             <%= fields_for "attendances[#{day.id}]" do |af| %>
-              <td><%= af.time_field :started_at, value: day.started_at&.strftime('%H:%M'),
-                                   class: "form-control form-control-sm", disabled: future %></td>
-              <td><%= af.time_field :finished_at, value: day.finished_at&.strftime('%H:%M'),
-                                   class: "form-control form-control-sm", disabled: future %></td>
+              <% started_hour = day.started_at&.hour %>
+              <% started_minute = day.started_at.present? ? (day.started_at.min / 15) * 15 : nil %>
+              <td>
+                <div class="d-flex gap-1 align-items-center">
+                  <select name="attendances[<%= day.id %>][started_at_hour]"
+                          class="form-control form-control-sm" <%= "disabled" if future %>>
+                    <option value="">--</option>
+                    <% (0..23).each do |h| %>
+                      <option value="<%= h %>" <%= "selected" if started_hour == h %>><%= format("%02d", h) %></option>
+                    <% end %>
+                  </select>
+                  <span>:</span>
+                  <select name="attendances[<%= day.id %>][started_at_minute]"
+                          class="form-control form-control-sm" <%= "disabled" if future %>>
+                    <option value="">--</option>
+                    <% [0, 15, 30, 45].each do |m| %>
+                      <option value="<%= m %>" <%= "selected" if started_minute == m %>><%= format("%02d", m) %></option>
+                    <% end %>
+                  </select>
+                </div>
+              </td>
+              <% finished_hour = if day.finished_at.present? && day.finished_at.to_date > day.worked_on
+                                   day.finished_at.hour + 24
+                                 elsif day.finished_at.present?
+                                   day.finished_at.hour
+                                 end %>
+              <% finished_minute = day.finished_at.present? ? (day.finished_at.min / 15) * 15 : nil %>
+              <td>
+                <div class="d-flex gap-1 align-items-center">
+                  <select name="attendances[<%= day.id %>][finished_at_hour]"
+                          class="form-control form-control-sm" <%= "disabled" if future %>>
+                    <option value="">--</option>
+                    <% (0..47).each do |h| %>
+                      <option value="<%= h %>" <%= "selected" if finished_hour == h %>><%= format("%02d", h) %></option>
+                    <% end %>
+                  </select>
+                  <span>:</span>
+                  <select name="attendances[<%= day.id %>][finished_at_minute]"
+                          class="form-control form-control-sm" <%= "disabled" if future %>>
+                    <option value="">--</option>
+                    <% [0, 15, 30, 45].each do |m| %>
+                      <option value="<%= m %>" <%= "selected" if finished_minute == m %>><%= format("%02d", m) %></option>
+                    <% end %>
+                  </select>
+                </div>
+              </td>
               <td>
                 <% if day.started_at.present? && day.finished_at.present? %>
                   <%= working_times(day.started_at, day.finished_at) %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -23,7 +23,7 @@
 </div>
 
 <div class="mb-3">
-  <%= link_to "勤怠を編集", edit_user_path(@user), class: "btn btn-outline-secondary btn-sm" %>
+  <%= link_to "勤怠を編集", edit_user_path(@user, date: @first_day), class: "btn btn-outline-secondary btn-sm" %>
 </div>
 
 <div>
@@ -67,13 +67,15 @@
           <% end %>
 
           <%# 退社列（時・分） %>
-          <% if day.worked_on == Date.current && day.started_at.present? && day.finished_at.nil? %>
+          <% if day.started_at.present? && day.finished_at.nil? %>
             <td colspan="2">
               <%= button_to "退社", user_attendance_path(@user, day),
                             method: :patch, class: "btn btn-warning btn-sm" %>
             </td>
           <% else %>
-            <td><%= floored_finished&.hour %></td>
+            <% finished_hour = floored_finished.present? && floored_finished.to_date > day.worked_on ?
+                               floored_finished.hour + 24 : floored_finished&.hour %>
+            <td><%= finished_hour %></td>
             <td><%= floored_finished&.strftime('%M') %></td>
           <% end %>
 


### PR DESCRIPTION
  ## 対応したissue
                                                                                                                                    
  ### #1 日付をまたぐ勤務時に退社ボタンが表示されず退勤打刻ができない
  - 退社ボタンの表示条件から日付チェック（`day.worked_on == Date.current`）を削除
  - 勤怠編集画面の出社・退社入力をセレクト形式に変更し、25:00などの日またぎ入力に対応
  - 表示画面で日またぎの退社時刻を25:xx形式で表示するよう対応                                                                       
                                                                                                                                    
  ※ 仕様書に記載のない追加対応として、編集画面でも日またぎ入力ができるよう実装しました。加藤先生からご提案いただいた「25:xx形式での表示・入力」をもとに実装しています。ご確認をお願いします。                                                                                                                      
                                                                                                                                    
  ### #2 月勤怠編集でトランザクションがなく一部保存が発生する                                                                       
  - `ActiveRecord::Base.transaction` でループ処理を囲み、1件でも失敗した場合は全件ロールバックするよう修正                          
                                                                                                                                    
  ### #3 勤怠編集後に編集した月ではなく当月の表示画面へ遷移してしまう                                                               
  - `redirect_to` に `date: @first_day` を渡すよう修正                                                                              
  - フォームの送信先URLにも `date: @first_day` を追加 
                                                                                                                                    
  ### #4 過去月の表示ページから「勤怠を編集」を押すと当月の編集画面が開いてしまう                                                   
  - 編集リンクに `date: @first_day` パラメータを追加